### PR TITLE
Add CTVIIntertalAPI cluster and route to gateway config

### DIFF
--- a/BackendAPI/BuildingBlocks/BuildingBlocks/SharedConstants/GatewayConstants.cs
+++ b/BackendAPI/BuildingBlocks/BuildingBlocks/SharedConstants/GatewayConstants.cs
@@ -5,6 +5,7 @@ public static class GatewayConstants
 	// Cluster IDs
 	public const string OnePlatformApi = "onePlatformApi";
 	public const string OnePlatformUI = "BlazorUI";
+	public const string CTVIIntertalAPI = "CTVIIntertalAPI";
 
 	// Rate limit policy names
 	public static class RateLimitPolicies

--- a/BackendAPI/Modules/Auth/Path/AuthPaths.cs
+++ b/BackendAPI/Modules/Auth/Path/AuthPaths.cs
@@ -403,6 +403,17 @@ public class AuthPaths : IReverseProxyModule
 			),
 
 			new RouteDefinitionDTO(
+				RouteId: "CTVIApi",
+				MatchPath: "CTVIAPI",
+				ClusterId: GatewayConstants.OnePlatformApi,
+				Methods: new [] { GatewayConstants.HttpMethod.Post },
+				Transforms: new Dictionary<string, string>
+				{
+					{ "PathSet", "webservice/product:35/.xml" }
+				}
+			),
+
+			new RouteDefinitionDTO(
 				RouteId: "FrontEndEntryPoint",
 				MatchPath: "/{**catchall}",
 				ClusterId: GatewayConstants.OnePlatformUI
@@ -433,7 +444,17 @@ public class AuthPaths : IReverseProxyModule
 						Address: "http://frontendwebassembly:8080"
 					)
 				}
-			)
+			),
+			new ClusterDefinitionDTO(
+				ClusterId: GatewayConstants.CTVIIntertalAPI,
+				Destinations: new []
+				{
+					new DestinationDefinitionDTO(
+						Id: "d1",
+						Address: "http://192.168.5.10"
+					)
+				}
+			),
 		};
 	}
 }


### PR DESCRIPTION
Added CTVIIntertalAPI constant and cluster definition. Introduced "CTVIApi" route for POST requests with path transform, targeting the new cluster at http://192.168.5.10.