### PR TITLE
Update cluster destination to use port 443

### DIFF
--- a/BackendAPI/Modules/Auth/Path/AuthPaths.cs
+++ b/BackendAPI/Modules/Auth/Path/AuthPaths.cs
@@ -451,7 +451,7 @@ public class AuthPaths : IReverseProxyModule
 				{
 					new DestinationDefinitionDTO(
 						Id: "d1",
-						Address: "http://192.168.5.10"
+						Address: "http://192.168.5.10:443"
 					)
 				}
 			),


### PR DESCRIPTION
Changed the destination address for the CTVIIntertalAPI cluster to explicitly specify port 443 in the DestinationDefinitionDTO constructor. This ensures the proxy targets the correct port.