### PR TITLE
Update ClusterId for CTVIApi route in AuthPaths

### DIFF
--- a/BackendAPI/Modules/Auth/Path/AuthPaths.cs
+++ b/BackendAPI/Modules/Auth/Path/AuthPaths.cs
@@ -405,7 +405,7 @@ public class AuthPaths : IReverseProxyModule
 			new RouteDefinitionDTO(
 				RouteId: "CTVIApi",
 				MatchPath: "CTVIAPI",
-				ClusterId: GatewayConstants.OnePlatformApi,
+				ClusterId: GatewayConstants.CTVIIntertalAPI,
 				Methods: new [] { GatewayConstants.HttpMethod.Post },
 				Transforms: new Dictionary<string, string>
 				{


### PR DESCRIPTION
Changed the ClusterId for the "CTVIApi" route from OnePlatformApi to CTVIIntertalAPI in the AuthPaths class to ensure correct routing.