### PR TITLE
Update CTVIIntertalAPI cluster to use HTTPS protocol

### DIFF
--- a/BackendAPI/Modules/Auth/Path/AuthPaths.cs
+++ b/BackendAPI/Modules/Auth/Path/AuthPaths.cs
@@ -451,7 +451,7 @@ public class AuthPaths : IReverseProxyModule
 				{
 					new DestinationDefinitionDTO(
 						Id: "d1",
-						Address: "http://192.168.5.10:443"
+						Address: "https://192.168.5.10:443"
 					)
 				}
 			),


### PR DESCRIPTION
Changed destination address for GatewayConstants.CTVIIntertalAPI from HTTP to HTTPS, updating "http://192.168.5.10:443" to "https://192.168.5.10:443" for improved security.