### PR TITLE
Disable SSL validation for specific YARP cluster

### DIFF
--- a/ApiGateways/YarpApiGateway/Extensions/GatewayServiceExtensions.cs
+++ b/ApiGateways/YarpApiGateway/Extensions/GatewayServiceExtensions.cs
@@ -198,7 +198,17 @@ public static class GatewayServiceExtensions
 		builder.Services.AddSingleton(catalog as ApiGateways.YarpApiGateway.Services.RouteCatalog);
 
 		builder.Services.AddReverseProxy()
-		.LoadFromMemory(yarpRoutes, yarpClusters);
+		.LoadFromMemory(yarpRoutes, yarpClusters)
+		.ConfigureHttpClient((context, handler) =>
+		{
+			if (handler is SocketsHttpHandler socketsHandler && context.ClusterId == GatewayConstants.CTVIIntertalAPI)
+			{
+				socketsHandler.SslOptions = new System.Net.Security.SslClientAuthenticationOptions
+				{
+					RemoteCertificateValidationCallback = (_, _, _, _) => true
+				};
+			}
+		});
 	}
 	#endregion
 }


### PR DESCRIPTION
Configured the YARP reverse proxy to disable SSL certificate validation for clusters with the ID GatewayConstants.CTVIIntertalAPI by setting SslOptions.RemoteCertificateValidationCallback to always return true. This allows connections to proceed even with invalid or self-signed certificates for that cluster.