### PR TITLE
Replace Guid.NewGuid with Guid.CreateVersion7 everywhere

### DIFF
--- a/BackendAPI/BuildingBlocks/BuildingBlocks/Storage/AlibabaOssStorageService .cs
+++ b/BackendAPI/BuildingBlocks/BuildingBlocks/Storage/AlibabaOssStorageService .cs
@@ -31,7 +31,7 @@ public sealed class AlibabaOssStorageService : IObjectStorageService
 		ArgumentNullException.ThrowIfNull(stream);
 
 		var objectKey = string.IsNullOrEmpty(_atsTestFolder)
-			? $"uploads/{Guid.NewGuid():N}-{fileName}"
+			? $"uploads/{Guid.CreateVersion7():N}-{fileName}"
 			: $"{_atsTestFolder.TrimEnd('/')}/{fileName}";
 
 		await Task.Run(() => { 

--- a/BackendAPI/Modules/AIAgent/Services/PolicyIngestionService/FileStorageService.cs
+++ b/BackendAPI/Modules/AIAgent/Services/PolicyIngestionService/FileStorageService.cs
@@ -20,7 +20,7 @@ public class FileStorageService : IFileStorageService
 
 	public async Task<string> SaveFileAsync(byte[] fileBytes, string fileName, CancellationToken cancellationToken = default)
 	{
-		var uniqueFileName = $"{Guid.NewGuid()}_{fileName}";
+		var uniqueFileName = $"{Guid.CreateVersion7()}_{fileName}";
 		var filePath = System.IO.Path.Combine(_storageDirectory, uniqueFileName);
 
 		await File.WriteAllBytesAsync(filePath, fileBytes, cancellationToken);

--- a/BackendAPI/Modules/Auth/Data/DataSeed/AuthInitialData.cs
+++ b/BackendAPI/Modules/Auth/Data/DataSeed/AuthInitialData.cs
@@ -9,7 +9,7 @@ public class AuthInitialData
 	public AuthInitialData(IPasswordHasherService passwordHasherService)
 	{
 		this._passwordHasherService = passwordHasherService;
-		this._Id = Guid.NewGuid();
+		this._Id = Guid.CreateVersion7();
 	}
 	public IEnumerable<Authusers> GetUsers()
 	{

--- a/BackendAPI/Modules/Auth/Data/Repository/AuthRepository.cs
+++ b/BackendAPI/Modules/Auth/Data/Repository/AuthRepository.cs
@@ -493,7 +493,7 @@ public class AuthRepository : IAuthRepository
 	{
 		var user = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = userDto.Email,
 			PasswordHash = userDto.PasswordHash,
 			FirstName = userDto.FirstName,

--- a/BackendAPI/Modules/Auth/Services/LoginService.cs
+++ b/BackendAPI/Modules/Auth/Services/LoginService.cs
@@ -360,7 +360,7 @@ public class LoginService : ILoginService
 		{
 			bool IsSaved = await _authRepository.SaveLockedUserAsync(lockedUser);
 			return true;
-		}	
+		}
 
 		if (lockedUserfromDB is not null)
 		{
@@ -517,7 +517,7 @@ public class LoginService : ILoginService
 			Action = "AuthenticateUser",
 			Step = "StartAuthentication",
 			RefreshToken = GetRefreshTokenFromCookie(),
-			RequestId = Guid.NewGuid(),
+			RequestId = Guid.CreateVersion7(),
 			Timestamp = DateTime.UtcNow
 		};
 

--- a/BackendAPI/Modules/Auth/Services/RegisterService.cs
+++ b/BackendAPI/Modules/Auth/Services/RegisterService.cs
@@ -90,7 +90,7 @@ public class RegisterService : IRegisterService
 		var user = new OtpVerification
 		{
 			Email = registerRequestDTO.Email,
-			OtpId = Guid.NewGuid(),
+			OtpId = Guid.CreateVersion7(),
 			FirstName = registerRequestDTO.FirstName,
 			LastName = registerRequestDTO.LastName,
 			MiddleName = registerRequestDTO.MiddleName!,
@@ -188,7 +188,7 @@ public class RegisterService : IRegisterService
 
 		var user = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = existingOtpRecord.Email,
 			PasswordHash = existingOtpRecord.PasswordHash,
 			FirstName = existingOtpRecord.FirstName,

--- a/BackendAPI/Modules/PhilSys/Services/PartnerSystemService.cs
+++ b/BackendAPI/Modules/PhilSys/Services/PartnerSystemService.cs
@@ -63,7 +63,7 @@ public class PartnerSystemService
 		{
 			transaction = new PhilSysTransaction
 			{
-				Tid = Guid.NewGuid(),
+				Tid = Guid.CreateVersion7(),
 				InquiryType = "name_dob",
 				FirstName = identity_data.FirstName,
 				MiddleName = identity_data.MiddleName,
@@ -82,7 +82,7 @@ public class PartnerSystemService
 		{
 			transaction = new PhilSysTransaction
 			{
-				Tid = Guid.NewGuid(),
+				Tid = Guid.CreateVersion7(),
 				InquiryType = "pcn",
 				PCN = identity_data.PCN,
 				IsTransacted = false,

--- a/Test/Test/BackendAPI/Modules/ATS.IntegrationTests/AddApplicationFormDataIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/ATS.IntegrationTests/AddApplicationFormDataIntegrationTests.cs
@@ -11,7 +11,7 @@ namespace Test.BackendAPI.Modules.ATS.IntegrationTests;
 public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 {
 	private readonly string _atsTestFolder;
-	Guid EmailId = Guid.NewGuid();
+	Guid EmailId = Guid.CreateVersion7();
 	byte[] sampleFileContent = Convert.FromBase64String("SGVsbG8gV29ybGQ=");
 	DateOnly sampleDate = DateOnly.FromDateTime(DateTime.UtcNow);
 	string govermentIdFileName = $"{Guid.NewGuid}-govId.txt";
@@ -53,7 +53,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 		var personal = new PersonalDetailsDTO
 		{
 			EmailInvitationID = EmailId,
-			PersonalID = Guid.NewGuid(),
+			PersonalID = Guid.CreateVersion7(),
 			PositionAppliedFor = "Senior Software Engineer",
 			FirstName = "Juan",
 			MiddleName = "Santos",
@@ -74,7 +74,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var address = new AddressDetailsDTO
 		{
-			Address = Guid.NewGuid(),
+			Address = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			CurrentCity = "Manila",
 			CurrentProvince = "Metro Manila",
@@ -92,7 +92,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var education = new EducationalBackgroundDTO
 		{
-			EducationalBackgroundID = Guid.NewGuid(),
+			EducationalBackgroundID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			HighestEducationalAttainment = "Bachelor's Degree",
 			HighSchoolName = "Manila Science High School",
@@ -123,7 +123,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var licenses = new LicensesDetailsDTO
 		{
-			LicensesDetailsID = Guid.NewGuid(),
+			LicensesDetailsID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			LicenseName = "AWS Certified Developer",
 			LicenseNumber = "AWS-DEV-2026-001",
@@ -135,7 +135,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var experiences = new ProfessionalExperiencesDTO
 		{
-			ProfessionalExperiencesID = Guid.NewGuid(),
+			ProfessionalExperiencesID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			Emp1CompanyName = "Accenture Philippines",
 			Emp1CurrentlyEmployed = false,
@@ -184,7 +184,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var reference = new ReferenceDetailsDTO
 		{
-			ReferenceDetailsID = Guid.NewGuid(),
+			ReferenceDetailsID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			Ref1FullName = "Michael Tan",
 			Ref1ProfessionalRelationship = "Former Team Lead",
@@ -212,7 +212,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var signature = new SignatureDetailsDTO
 		{
-			SignatureDetailsID = Guid.NewGuid(),
+			SignatureDetailsID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			Signature = CreateFakeFormFile(sampleFileContent, signatureFileName),
 		};
@@ -254,7 +254,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var address = new AddressDetailsDTO
 		{
-			Address = Guid.NewGuid(),
+			Address = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			CurrentCity = "Manila",
 			CurrentProvince = "Metro Manila",
@@ -272,7 +272,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var education = new EducationalBackgroundDTO
 		{
-			EducationalBackgroundID = Guid.NewGuid(),
+			EducationalBackgroundID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			HighestEducationalAttainment = "Bachelor's Degree",
 			HighSchoolName = "Manila Science High School",
@@ -303,7 +303,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var licenses = new LicensesDetailsDTO
 		{
-			LicensesDetailsID = Guid.NewGuid(),
+			LicensesDetailsID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			LicenseName = "AWS Certified Developer",
 			LicenseNumber = "AWS-DEV-2026-001",
@@ -315,7 +315,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var experiences = new ProfessionalExperiencesDTO
 		{
-			ProfessionalExperiencesID = Guid.NewGuid(),
+			ProfessionalExperiencesID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			Emp1CompanyName = "Accenture Philippines",
 			Emp1CurrentlyEmployed = false,
@@ -364,7 +364,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var reference = new ReferenceDetailsDTO
 		{
-			ReferenceDetailsID = Guid.NewGuid(),
+			ReferenceDetailsID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 
 			Ref1FullName = "Michael Tan",
@@ -396,7 +396,7 @@ public class AddApplicationFormDataIntegrationTests : BaseIntegrationTest
 
 		var signature = new SignatureDetailsDTO
 		{
-			SignatureDetailsID = Guid.NewGuid(),
+			SignatureDetailsID = Guid.CreateVersion7(),
 			EmailInvitationID = EmailId,
 			Signature = CreateFakeFormFile(sampleFileContent, "signature.txt"),
 		};

--- a/Test/Test/BackendAPI/Modules/ATS.IntegrationTests/GetEmailIdAndApplicationFormPathIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/ATS.IntegrationTests/GetEmailIdAndApplicationFormPathIntegrationTests.cs
@@ -18,7 +18,7 @@ public class GetEmailIdAndApplicationFormPathIntegrationTests : BaseIntegrationT
 	public async Task GetEmailIdAndApplicationFormPath_WithValidHashToken_ShouldReturnEmailIdAndPath()
 	{
 		// Arrange
-		Guid emailId = Guid.NewGuid();
+		Guid emailId = Guid.CreateVersion7();
 		string _hashToken = "valid-hash-token-xyz";
 
 		await SeedEmailInvitationRequestData(emailId, _hashToken);

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/AppSubRoleIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/AppSubRoleIntegrationTests.cs
@@ -99,8 +99,8 @@ public class AppSubRoleIntegrationTests : BaseIntegrationTest
 	public async Task AddAppSubRole_ShouldAddNewAppSubRoleSuccessfully()
 	{
 		// Arrange
-		var assignedByUser = new Authusers { Id = Guid.NewGuid(), Email = "admin@test.com" };
-		var targetUser = new Authusers { Id = Guid.NewGuid(), Email = "user@test.com" };
+		var assignedByUser = new Authusers { Id = Guid.CreateVersion7(), Email = "admin@test.com" };
+		var targetUser = new Authusers { Id = Guid.CreateVersion7(), Email = "user@test.com" };
 
 		_dbContext.AuthUsers.AddRange(assignedByUser, targetUser);
 		_dbContext.AuthApplications.Add(new AuthApplication { AppId = 1, AppName = "App 1" });
@@ -133,7 +133,7 @@ public class AppSubRoleIntegrationTests : BaseIntegrationTest
 	public async Task EditAppSubRole_ShouldUpdateExistingAppSubRoleSuccessfully()
 	{
 		// Arrange
-		await SeedAppSubRoleData(); 
+		await SeedAppSubRoleData();
 
 		var existingAppSubRole = await _dbContext.AuthUserAppRoles
 			.AsNoTracking()
@@ -173,7 +173,7 @@ public class AppSubRoleIntegrationTests : BaseIntegrationTest
 		var editDto = new EditAppSubRoleDTO
 		{
 			AppSubRoleId = 999, // Non-existent ID
-			UserId = Guid.NewGuid(),
+			UserId = Guid.CreateVersion7(),
 			AppId = 1,
 			SubMenuId = 1,
 			RoleId = 1
@@ -194,7 +194,7 @@ public class AppSubRoleIntegrationTests : BaseIntegrationTest
 	public async Task DeleteAppSubRole_ShouldRemoveAppSubRoleSuccessfully()
 	{
 		// Arrange
-		await SeedAppSubRoleData(); 
+		await SeedAppSubRoleData();
 
 		var command = new DeleteAppSubRoleCommand(1);
 
@@ -245,14 +245,14 @@ public class AppSubRoleIntegrationTests : BaseIntegrationTest
 		// Seed Users (required!)
 		var assignedByUser = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = "admin@test.com",
 			FirstName = "Admin"
 		};
 
-		var user1 = new Authusers { Id = Guid.NewGuid(), Email = "u1@test.com" };
-		var user2 = new Authusers { Id = Guid.NewGuid(), Email = "u2@test.com" };
-		var user3 = new Authusers { Id = Guid.NewGuid(), Email = "u3@test.com" };
+		var user1 = new Authusers { Id = Guid.CreateVersion7(), Email = "u1@test.com" };
+		var user2 = new Authusers { Id = Guid.CreateVersion7(), Email = "u2@test.com" };
+		var user3 = new Authusers { Id = Guid.CreateVersion7(), Email = "u3@test.com" };
 
 		_dbContext.AuthUsers.AddRange(assignedByUser, user1, user2, user3);
 
@@ -277,7 +277,7 @@ public class AppSubRoleIntegrationTests : BaseIntegrationTest
 			new AuthRole { RoleId = 3, RoleName = "Role 3" }
 		);
 
-		await _dbContext.SaveChangesAsync(); 
+		await _dbContext.SaveChangesAsync();
 
 		// Seed AuthUserAppRoles
 		_dbContext.AuthUserAppRoles.AddRange(

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/GetAccessTokenIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/GetAccessTokenIntegrationTests.cs
@@ -18,7 +18,7 @@ public class GetAccessTokenIntegrationTests : BaseIntegrationTest
 	public async Task GetNewAccessToken_ShouldThrowNotFound_WhenUserDoesNotExist()
 	{
 		// Arrange
-		var nonExistentUserId = Guid.NewGuid();
+		var nonExistentUserId = Guid.CreateVersion7();
 
 		var command = new GetNewAccessTokenCommand(nonExistentUserId);
 
@@ -35,7 +35,7 @@ public class GetAccessTokenIntegrationTests : BaseIntegrationTest
 		// Arrange - seed user and refresh token in DB
 		var user = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = "refreshuser@example.com",
 			PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 			FirstName = "Refresh",

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/LockedUserIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/LockedUserIntegrationTests.cs
@@ -55,7 +55,7 @@ public class LockedUserIntegrationTests : BaseIntegrationTest
 	public async Task DeleteLockedUser_ShouldRemoveLockedUserSuccessfully()
 	{
 		// Arrange
-		var id = Guid.NewGuid();
+		var id = Guid.CreateVersion7();
 		var locked = new AuthAttempts
 		{
 			UserId = id,
@@ -84,7 +84,7 @@ public class LockedUserIntegrationTests : BaseIntegrationTest
 	public async Task DeleteLockedUser_ShouldThrow_WhenLockedUserDoesNotExist()
 	{
 		// Arrange
-		var id = Guid.NewGuid();
+		var id = Guid.CreateVersion7();
 		var command = new DeleteLockedUserCommand(id);
 
 		// Act
@@ -99,9 +99,9 @@ public class LockedUserIntegrationTests : BaseIntegrationTest
 	{
 		var attempts = new List<AuthAttempts>
 		{
-			new AuthAttempts { UserId = Guid.NewGuid(), Message = "Account is locked due to too many failed attempts.", Email = "a@example.com", Attempts = 4, CreatedAt = DateTime.UtcNow, LockReleaseAt = DateTime.UtcNow.AddMinutes(40) },
-			new AuthAttempts { UserId = Guid.NewGuid(), Message = "Account is locked due to too many failed attempts.", Email = "b@example.com", Attempts = 4, CreatedAt = DateTime.UtcNow, LockReleaseAt = DateTime.UtcNow.AddMinutes(30) },
-			new AuthAttempts { UserId = Guid.NewGuid(), Message = "Account is locked due to too many failed attempts.", Email = "c@example.com", Attempts = 5, CreatedAt = DateTime.UtcNow, LockReleaseAt = DateTime.UtcNow.AddMinutes(20) }
+			new AuthAttempts { UserId = Guid.CreateVersion7(), Message = "Account is locked due to too many failed attempts.", Email = "a@example.com", Attempts = 4, CreatedAt = DateTime.UtcNow, LockReleaseAt = DateTime.UtcNow.AddMinutes(40) },
+			new AuthAttempts { UserId = Guid.CreateVersion7(), Message = "Account is locked due to too many failed attempts.", Email = "b@example.com", Attempts = 4, CreatedAt = DateTime.UtcNow, LockReleaseAt = DateTime.UtcNow.AddMinutes(30) },
+			new AuthAttempts { UserId = Guid.CreateVersion7(), Message = "Account is locked due to too many failed attempts.", Email = "c@example.com", Attempts = 5, CreatedAt = DateTime.UtcNow, LockReleaseAt = DateTime.UtcNow.AddMinutes(20) }
 		};
 
 		_dbContext.AuthAttempts.AddRange(attempts);

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/LoginIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/LoginIntegrationTests.cs
@@ -279,7 +279,7 @@ public class LoginIntegrationTests : BaseIntegrationTest
 
 	private async Task SeedUserData()
 	{
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 
 		var user = new Authusers
 		{
@@ -373,7 +373,7 @@ public class LoginIntegrationTests : BaseIntegrationTest
 
 	private async Task SeedUserOnlyData()
 	{
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 
 		var user = new Authusers
 		{
@@ -392,7 +392,7 @@ public class LoginIntegrationTests : BaseIntegrationTest
 
 	private async Task SeedUserDataWithLockedAccount()
 	{
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 
 		var user = new Authusers
 		{

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/LogoutIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/LogoutIntegrationTests.cs
@@ -39,7 +39,7 @@ public class LogoutIntegrationTests : BaseIntegrationTest
 		// Arrange: seed user but do not set cookie and do not add refresh token
 		var user = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = "nocookie@example.com",
 			PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 			FirstName = "No",
@@ -66,7 +66,7 @@ public class LogoutIntegrationTests : BaseIntegrationTest
 	public async Task Logout_ShouldThrowNotFound_WhenUserHasNoRefreshRecord()
 	{
 		// Arrange
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var user = new Authusers
 		{
 			Id = userId,
@@ -98,7 +98,7 @@ public class LogoutIntegrationTests : BaseIntegrationTest
 	{
 		var user = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = "logoutuser@example.com",
 			PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 			FirstName = "Test",

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/PasswordTokenIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/PasswordTokenIntegrationTests.cs
@@ -19,7 +19,7 @@ public class PasswordTokenIntegrationTests : BaseIntegrationTest
 		// Arrange
 		var user = await SeedUserData();
 
-		var tokenHash = Guid.NewGuid().ToString();
+		var tokenHash = Guid.CreateVersion7().ToString();
 
 		var passwordToken = new PasswordResetToken
 		{
@@ -51,7 +51,7 @@ public class PasswordTokenIntegrationTests : BaseIntegrationTest
 		// Arrange
 		var user = await SeedUserData();
 
-		var tokenHash = Guid.NewGuid().ToString();
+		var tokenHash = Guid.CreateVersion7().ToString();
 
 		var passwordToken = new PasswordResetToken
 		{
@@ -105,7 +105,7 @@ public class PasswordTokenIntegrationTests : BaseIntegrationTest
 	{
 		// Arrange - create expired token
 		var user = await SeedUserData();
-		var tokenHash = Guid.NewGuid().ToString();
+		var tokenHash = Guid.CreateVersion7().ToString();
 		var passwordToken = new PasswordResetToken
 		{
 			UserId = user.Id,
@@ -132,7 +132,7 @@ public class PasswordTokenIntegrationTests : BaseIntegrationTest
 	{
 		var user = new Authusers
 		{
-			Id = Guid.NewGuid(),
+			Id = Guid.CreateVersion7(),
 			Email = "jane2@example.com",
 			PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 			FirstName = "Test",

--- a/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/UserManagementIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.IntegrationTests/UserManagementIntegrationTests.cs
@@ -239,7 +239,7 @@ public class UserManagementIntegrationTests : BaseIntegrationTest
 		{
 			new Authusers
 			{
-				Id = Guid.NewGuid(),
+				Id = Guid.CreateVersion7(),
 				Email = "john@example1.com",
 				PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 				FirstName = "Admin1",
@@ -248,7 +248,7 @@ public class UserManagementIntegrationTests : BaseIntegrationTest
 			},
 			new Authusers
 			{
-				Id = Guid.NewGuid(),
+				Id = Guid.CreateVersion7(),
 				Email = "john@example2.com",
 				PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 				FirstName = "Admin2",
@@ -257,7 +257,7 @@ public class UserManagementIntegrationTests : BaseIntegrationTest
 			},
 			new Authusers
 			{
-				Id = Guid.NewGuid(),
+				Id = Guid.CreateVersion7(),
 				Email = "john@example3.com",
 				PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 				FirstName = "Admin3",
@@ -266,7 +266,7 @@ public class UserManagementIntegrationTests : BaseIntegrationTest
 			},
 			new Authusers
 			{
-				Id = Guid.NewGuid(),
+				Id = Guid.CreateVersion7(),
 				Email = "john@example4.com",
 				PasswordHash = _passwordHasherService.HashPassword("p@ssw0rd!"),
 				FirstName = "Admin4",

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/AppSubRoleServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/AppSubRoleServiceTests.cs
@@ -29,8 +29,8 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 
 		var data = new List<AppSubRolesDTO>
 			{
-				new AppSubRolesDTO ( 1, Guid.NewGuid(), "john@example.com", 1, "PhilSys", 1, "IDV", 1, "SuperAdmin" ),
-				new AppSubRolesDTO ( 2, Guid.NewGuid(), "doe@example.com", 2, "CNX", 2, "DashBoard", 2, "Admin" )
+				new AppSubRolesDTO ( 1, Guid.CreateVersion7(), "john@example.com", 1, "PhilSys", 1, "IDV", 1, "SuperAdmin" ),
+				new AppSubRolesDTO ( 2, Guid.CreateVersion7(), "doe@example.com", 2, "CNX", 2, "DashBoard", 2, "Admin" )
 			};
 
 		var expectedResult = new PaginatedResult<AppSubRolesDTO>(1, 1, 10, data);
@@ -63,8 +63,8 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 
 		var data = new List<AppSubRolesDTO>
 			{
-				new AppSubRolesDTO ( 1, Guid.NewGuid(), "john@example.com", 1, "PhilSys", 1, "IDV", 1, "SuperAdmin" ),
-				new AppSubRolesDTO ( 2, Guid.NewGuid(), "doe@example.com", 2, "CNX", 2, "DashBoard", 2, "Admin" )
+				new AppSubRolesDTO ( 1, Guid.CreateVersion7(), "john@example.com", 1, "PhilSys", 1, "IDV", 1, "SuperAdmin" ),
+				new AppSubRolesDTO ( 2, Guid.CreateVersion7(), "doe@example.com", 2, "CNX", 2, "DashBoard", 2, "Admin" )
 			};
 
 		var expectedResult = new PaginatedResult<AppSubRolesDTO>(1, 1, 10, data);
@@ -88,7 +88,7 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task AddAppSubRoleAsync_ShouldReturnTrue_WhenSuccessful()
 	{
 		// Arrange
-		var appSubRole = new AddAppSubRoleDTO { UserId = Guid.NewGuid(), AppId = 1, SubMenuId = 1, RoleId = 1, AssignedBy = Guid.NewGuid() };
+		var appSubRole = new AddAppSubRoleDTO { UserId = Guid.CreateVersion7(), AppId = 1, SubMenuId = 1, RoleId = 1, AssignedBy = Guid.CreateVersion7() };
 
 		_fixture.MockAuthRepository
 			.Setup(x => x.AddAppSubRoleAsync(appSubRole))
@@ -105,7 +105,7 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task EditAppSubRolesync_ShouldThrow_WhenAppSubRoleNotFound()
 	{
 		// Arrange
-		var editDto = new EditAppSubRoleDTO { AppSubRoleId = 1, UserId = Guid.NewGuid(), AppId = 1, SubMenuId = 1, RoleId = 1 };
+		var editDto = new EditAppSubRoleDTO { AppSubRoleId = 1, UserId = Guid.CreateVersion7(), AppId = 1, SubMenuId = 1, RoleId = 1 };
 
 		_fixture.MockAuthRepository
 			.Setup(x => x.GetAppSubRoleAsync(editDto.AppSubRoleId))
@@ -123,9 +123,9 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task EditAppSubRolesync_ShouldReturnUpdatedDto_WhenSuccessful()
 	{
 		// Arrange
-		var editDto = new EditAppSubRoleDTO { AppSubRoleId = 1, UserId = Guid.NewGuid(), AppId = 2, SubMenuId = 2, RoleId = 2 };
-		var existingAppSubRole = new AuthUserAppRole { AppRoleId = 1, UserId = Guid.NewGuid(), AppId = 1, Submenu = 1, RoleId = 1 };
-		var updatedAppSubRole = new AuthUserAppRole { AppRoleId = 1, UserId = Guid.NewGuid(), AppId = 2, Submenu = 2, RoleId = 2 };
+		var editDto = new EditAppSubRoleDTO { AppSubRoleId = 1, UserId = Guid.CreateVersion7(), AppId = 2, SubMenuId = 2, RoleId = 2 };
+		var existingAppSubRole = new AuthUserAppRole { AppRoleId = 1, UserId = Guid.CreateVersion7(), AppId = 1, Submenu = 1, RoleId = 1 };
+		var updatedAppSubRole = new AuthUserAppRole { AppRoleId = 1, UserId = Guid.CreateVersion7(), AppId = 2, Submenu = 2, RoleId = 2 };
 
 		_fixture.MockAuthRepository
 			.Setup(x => x.GetAppSubRoleAsync(editDto.AppSubRoleId))
@@ -169,7 +169,7 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var appSubRoleId = 1;
-		var existingAppSubRole= new AuthUserAppRole { AppRoleId = appSubRoleId, UserId = Guid.NewGuid(), AppId = 1, Submenu = 1, RoleId = 1 };
+		var existingAppSubRole = new AuthUserAppRole { AppRoleId = appSubRoleId, UserId = Guid.CreateVersion7(), AppId = 1, Submenu = 1, RoleId = 1 };
 
 		_fixture.MockAuthRepository
 			.Setup(x => x.GetAppSubRoleAsync(appSubRoleId))
@@ -198,7 +198,7 @@ public class AppSubRoleServiceTests : IClassFixture<AuthServiceFixture>
 			Role = "SuperAdmin"
 		};
 
-	
+
 		_fixture.MockEmailService.Setup(x => x.SendNotificationBody(request.Gmail, request.Application, request.SubMenu, request.Role)).Returns("body");
 		_fixture.MockEmailService
 			.Setup(x => x.SendEmailAsync(request.Gmail, "Account Assignment Notification", It.IsAny<string>(), It.IsAny<bool>()))

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/JWTServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/JWTServiceTests.cs
@@ -30,7 +30,7 @@ public class JWTServiceTests
 		// Arrange
 		var cfg = BuildConfiguration();
 		var service = new JWTService(cfg);
-		var dto = new LoginDTO(Guid.NewGuid(), "hash", "user@example.com", "First", "Last", null, true, new List<int>(), new List<List<int>>(), new List<int>());
+		var dto = new LoginDTO(Guid.CreateVersion7(), "hash", "user@example.com", "First", "Last", null, true, new List<int>(), new List<List<int>>(), new List<int>());
 
 		// Act
 		var token = service.GetAccessToken(dto);

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/LockedUserServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/LockedUserServiceTests.cs
@@ -19,7 +19,7 @@ public class LockedUserServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task DeleteLockedUserAsync_ShouldDeleteLockedUser_WhenLockedUserExists()
 	{
 		// Arrange
-		var lockedUserId = Guid.NewGuid();
+		var lockedUserId = Guid.CreateVersion7();
 		var lockedUser = new AuthAttempts { UserId = lockedUserId };
 		_fixture.MockAuthRepository
 			.Setup(x => x.GetLockedUserAsync(lockedUserId))
@@ -37,7 +37,7 @@ public class LockedUserServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task DeleteLockedUserAsync_ShouldThrow_WhenLockedUserNotFound()
 	{
 		// Arrange
-		var lockedUserId = Guid.NewGuid();
+		var lockedUserId = Guid.CreateVersion7();
 		_fixture.MockAuthRepository
 			.Setup(x => x.GetLockedUserAsync(lockedUserId))
 			.ReturnsAsync((AuthAttempts?)null);
@@ -63,8 +63,8 @@ public class LockedUserServiceTests : IClassFixture<AuthServiceFixture>
 
 		var attempts = new List<AuthAttempts>
 		{
-			new AuthAttempts { UserId = Guid.NewGuid(), Attempts = 1, CreatedAt = DateTime.UtcNow },
-			new AuthAttempts { UserId = Guid.NewGuid(), Attempts = 2, CreatedAt = DateTime.UtcNow }
+			new AuthAttempts { UserId = Guid.CreateVersion7(), Attempts = 1, CreatedAt = DateTime.UtcNow },
+			new AuthAttempts { UserId = Guid.CreateVersion7(), Attempts = 2, CreatedAt = DateTime.UtcNow }
 		};
 
 		var expectedResult = new PaginatedResult<AuthAttempts>(1, 10, attempts.Count, attempts);
@@ -97,7 +97,7 @@ public class LockedUserServiceTests : IClassFixture<AuthServiceFixture>
 
 		var attempts = new List<AuthAttempts>
 		{
-			new AuthAttempts { UserId = Guid.NewGuid(), Email = "test@example.com", Attempts = 4, CreatedAt = DateTime.UtcNow }
+			new AuthAttempts { UserId = Guid.CreateVersion7(), Email = "test@example.com", Attempts = 4, CreatedAt = DateTime.UtcNow }
 		};
 
 		var expectedResult = new PaginatedResult<AuthAttempts>(1, 10, attempts.Count, attempts);

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/LoginServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/LoginServiceTests.cs
@@ -37,7 +37,7 @@ public class LoginServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.LoginService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var loginDto = new LoginDTO(userId, "hash", "email@example.com", "F", "L", null, true, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
 
 		_fixture.MockAuthRepository.Setup(x => x.GetUserDataAsync(It.IsAny<LoginWebCred>())).ReturnsAsync(loginDto);
@@ -57,7 +57,7 @@ public class LoginServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.LoginService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var loginDto = new LoginDTO(userId, "hash", "email@example.com", "John", "Doe", null, true, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
 
 		_fixture.MockAuthRepository.Setup(x => x.GetUserDataAsync(It.IsAny<LoginWebCred>())).ReturnsAsync(loginDto);
@@ -79,7 +79,7 @@ public class LoginServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.LoginService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var loginDto = new LoginDTO(userId, "hash", "email@example.com", "John", "Doe", null, true, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
 
 		// Setup a dictionary to simulate cache persistence across calls
@@ -174,7 +174,7 @@ public class LoginServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.LoginService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var loginDto = new LoginDTO(userId, "hash", "email@example.com", "John", "Doe", null, true, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
 		var lockedUser = new AuthAttempts
 		{
@@ -203,7 +203,7 @@ public class LoginServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.LoginService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var loginDto = new LoginDTO(userId, "hash", "email@example.com", "John", "Doe", null, true, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
 		var expiredLockedUser = new AuthAttempts
 		{
@@ -235,7 +235,7 @@ public class LoginServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.LoginService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var loginDto = new LoginDTO(userId, "hash", "email@example.com", "John", "Doe", null, false, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
 
 		_fixture.MockAuthRepository.Setup(x => x.GetUserDataAsync(It.IsAny<LoginWebCred>())).ReturnsAsync(loginDto);

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/RefreshTokenServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/RefreshTokenServiceTests.cs
@@ -54,7 +54,7 @@ public class RefreshTokenServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.RefreshTokenService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		_fixture.MockAuthRepository.Setup(x => x.GetNewUserDataAsync(userId)).ReturnsAsync((UserDataDTO?)null);
 
 		// Act
@@ -69,7 +69,7 @@ public class RefreshTokenServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.RefreshTokenService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		// stored hash is for a different token
 		var storedHash = service.HashToken("storedtoken");
 		var userData = new UserDataDTO(userId, "pw", "email@example.com", "F", "L", null, string.Empty, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
@@ -94,7 +94,7 @@ public class RefreshTokenServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.RefreshTokenService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var refreshToken = "refreshtoken";
 		var storedHash = service.HashToken(refreshToken);
 		var userData = new UserDataDTO(userId, "pw", "email@example.com", "F", "L", null, storedHash, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });
@@ -135,7 +135,7 @@ public class RefreshTokenServiceTests : IClassFixture<AuthServiceFixture>
 	{
 		// Arrange
 		var service = _fixture.RefreshTokenService;
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var refreshToken = "refreshtoken";
 		var storedHash = service.HashToken(refreshToken);
 		var userData = new UserDataDTO(userId, "pw", "email@example.com", "F", "L", null, storedHash, new List<int> { 1 }, new List<List<int>> { new List<int> { 1 } }, new List<int> { 1 });

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/RegisterServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/RegisterServiceTests.cs
@@ -221,9 +221,9 @@ public class RegisterServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task ManualResendOtpCodeAsync_ShouldReturnTrue_WhenSuccessful()
 	{
 		// Arrange
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var email = "manresend@example.com";
-		var otpRecord = new OtpVerification { Email = email, OtpId = Guid.NewGuid(), FirstName = "F", LastName = "L" };
+		var otpRecord = new OtpVerification { Email = email, OtpId = Guid.CreateVersion7(), FirstName = "F", LastName = "L" };
 
 		_fixture.MockAuthRepository.Setup(x => x.IsUserEmailExistInOtpVerificationAsync(email, false))
 			.ReturnsAsync(otpRecord);
@@ -251,7 +251,7 @@ public class RegisterServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task ManualResendOtpCodeAsync_ShouldThrow_WhenNoRecord()
 	{
 		// Arrange
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var email = "missing@example.com";
 		_fixture.MockAuthRepository.Setup(x => x.IsUserEmailExistInOtpVerificationAsync(email, false))
 			.ReturnsAsync((OtpVerification?)null);
@@ -267,7 +267,7 @@ public class RegisterServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task IsOtpSessionValidAsync_ShouldReturnFalse_WhenNoRecord()
 	{
 		// Arrange
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var email = "novalid@example.com";
 		_fixture.MockAuthRepository.Setup(x => x.OtpVerificationUserData(It.IsAny<OtpVerificationRequestDTO>()))
 			.ReturnsAsync((OtpVerification?)null);
@@ -283,7 +283,7 @@ public class RegisterServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task IsOtpSessionValidAsync_ShouldReturnFalse_WhenUsed()
 	{
 		// Arrange
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var email = "usedsession@example.com";
 		var record = new OtpVerification { Email = email, IsUsed = true };
 		_fixture.MockAuthRepository.Setup(x => x.OtpVerificationUserData(It.IsAny<OtpVerificationRequestDTO>()))
@@ -300,7 +300,7 @@ public class RegisterServiceTests : IClassFixture<AuthServiceFixture>
 	public async Task IsOtpSessionValidAsync_ShouldReturnTrue_WhenValid()
 	{
 		// Arrange
-		var userId = Guid.NewGuid();
+		var userId = Guid.CreateVersion7();
 		var email = "validsession@example.com";
 		var record = new OtpVerification { Email = email, IsUsed = false };
 		_fixture.MockAuthRepository.Setup(x => x.OtpVerificationUserData(It.IsAny<OtpVerificationRequestDTO>()))

--- a/Test/Test/BackendAPI/Modules/Auth.UnitTests/UserManagementServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Auth.UnitTests/UserManagementServiceTests.cs
@@ -31,8 +31,8 @@ public class UserManagementServiceTests : IClassFixture<AuthServiceFixture>
 
 		var userData = new List<UsersDTO>
 			{
-				new UsersDTO(Guid.NewGuid(), "user1@example.com", "sample1" , "sample2" , null, false),
-				new UsersDTO(Guid.NewGuid(), "user2@example.com", "sample3" , "sample4" , null, false)
+				new UsersDTO(Guid.CreateVersion7(), "user1@example.com", "sample1" , "sample2" , null, false),
+				new UsersDTO(Guid.CreateVersion7(), "user2@example.com", "sample3" , "sample4" , null, false)
 			};
 
 		var expectedResult = new PaginatedResult<UsersDTO>(1, 2, 10, userData);
@@ -67,7 +67,7 @@ public class UserManagementServiceTests : IClassFixture<AuthServiceFixture>
 
 		var userData = new List<UsersDTO>
 			{
-				new UsersDTO(Guid.NewGuid(), "user1@example.com", "sample1" , "sample2" , null, false)
+				new UsersDTO(Guid.CreateVersion7(), "user1@example.com", "sample1" , "sample2" , null, false)
 			};
 
 		var expectedResult = new PaginatedResult<UsersDTO>(1, 2, 10, userData);
@@ -102,8 +102,8 @@ public class UserManagementServiceTests : IClassFixture<AuthServiceFixture>
 
 		var userData = new List<UsersDTO>
 			{
-				new UsersDTO(Guid.NewGuid(), "user1@example.com", "sample1" , "sample2" , null, false),
-				new UsersDTO(Guid.NewGuid(), "user2@example.com", "sample3" , "sample4" , null, false)
+				new UsersDTO(Guid.CreateVersion7(), "user1@example.com", "sample1" , "sample2" , null, false),
+				new UsersDTO(Guid.CreateVersion7(), "user2@example.com", "sample3" , "sample4" , null, false)
 			};
 
 		var expectedResult = new PaginatedResult<UsersDTO>(1, 2, 10, userData);
@@ -138,7 +138,7 @@ public class UserManagementServiceTests : IClassFixture<AuthServiceFixture>
 
 		var userData = new List<UsersDTO>
 			{
-				new UsersDTO(Guid.NewGuid(), "user1@example.com", "sample1" , "sample2" , null, false)
+				new UsersDTO(Guid.CreateVersion7(), "user1@example.com", "sample1" , "sample2" , null, false)
 			};
 
 		var expectedResult = new PaginatedResult<UsersDTO>(1, 2, 10, userData);

--- a/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/DeleteTransactionIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/DeleteTransactionIntegrationTests.cs
@@ -34,7 +34,7 @@ public class DeleteTransactionIntegrationTests : BaseIntegrationTest
             // Arrange
             var transaction = new PhilSysTransaction
             {
-                Tid = Guid.NewGuid(),
+                Tid = Guid.CreateVersion7(),
                 InquiryType = "pcn",
                 PCN = "9700018324631576",
                 WebHookUrl = "/",

--- a/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/LivenessSessionIntegrationTesting.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/LivenessSessionIntegrationTesting.cs
@@ -37,7 +37,7 @@ public class LivenessSessionIntegrationTesting : BaseIntegrationTest
 
 		var transaction = new PhilSysTransaction
 		{
-			Tid = Guid.NewGuid(),
+			Tid = Guid.CreateVersion7(),
 			InquiryType = "pcn",
 			PCN = "9700018324631576",
 			WebHookUrl = "/callback",

--- a/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/PhilSysServiceIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/PhilSysServiceIntegrationTests.cs
@@ -40,7 +40,7 @@ public class PhilSysServiceIntegrationTests : BaseIntegrationTest
 		using var scope = customFactory.Services.CreateScope();
 		var sender = scope.ServiceProvider.GetRequiredService<ISender>();
 
-		var command = new GetPhilSysTokenCommand(Guid.NewGuid().ToString(), "secret");
+		var command = new GetPhilSysTokenCommand(Guid.CreateVersion7().ToString(), "secret");
 
 		// Act
 		var result = await sender.Send(command);
@@ -65,7 +65,7 @@ public class PhilSysServiceIntegrationTests : BaseIntegrationTest
 		using var scope = customFactory.Services.CreateScope();
 		var sender = scope.ServiceProvider.GetRequiredService<ISender>();
 
-		var command = new GetPhilSysTokenCommand(Guid.NewGuid().ToString(), "secret");
+		var command = new GetPhilSysTokenCommand(Guid.CreateVersion7().ToString(), "secret");
 
 		// Act
 		Func<Task> act = async () => await sender.Send(command);

--- a/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/UpdateFaceLivenessSessionIntegrationTests.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.IntegrationTests/UpdateFaceLivenessSessionIntegrationTests.cs
@@ -30,7 +30,7 @@ public class UpdateFaceLivenessSessionIntegrationTests_CreateFactoryWithHandler 
 
 		var transaction = new PhilSysTransaction
 		{
-			Tid = Guid.NewGuid(),
+			Tid = Guid.CreateVersion7(),
 			InquiryType = "name_dob",
 			FirstName = "Juan",
 			MiddleName = "Bitaw",

--- a/Test/Test/BackendAPI/Modules/PhilSys.UnitTests/LivenessSessionServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.UnitTests/LivenessSessionServiceTests.cs
@@ -49,7 +49,7 @@ namespace Test.BackendAPI.Modules.PhilSys.UnitTests
 		public async Task LivenessSessionService_ShouldThrow_WhenTokenIsInvalid()
 		{
 			var service = _fixture.LivenessSessionService;
-			var Tid = Guid.NewGuid();
+			var Tid = Guid.CreateVersion7();
 			var transactionStatus = new TransactionStatusResponse { Exists = true, WebHookURl = "/", IsTransacted = false, isExpired = false, ExpiresAt = DateTime.UtcNow };
 			var transactionRecord = new PhilSysTransaction { Tid = Tid, InquiryType = "pcn", PCN = "6786785465456459"};
 			_fixture.MockPhilSysRepository.Setup(x => x.GetLivenessSessionStatusAsync(It.IsAny<string>())).ReturnsAsync(transactionStatus);
@@ -67,7 +67,7 @@ namespace Test.BackendAPI.Modules.PhilSys.UnitTests
 		public async Task LivenessSessionService_ShouldReturnTransactionResponseDTO_WhenSuccessful()
 		{
 			var service = _fixture.LivenessSessionService;
-			var Tid = Guid.NewGuid();
+			var Tid = Guid.CreateVersion7();
 			var FixedUtcNow = new DateTime(2025, 11, 9, 0, 0, 0, DateTimeKind.Utc);
 			var transactionStatus = new TransactionStatusResponse { Exists = true, WebHookURl = "/", IsTransacted = false, isExpired = false, ExpiresAt = FixedUtcNow };
 			var transactionStatusDTO = new TransactionStatusResponseDTO { Exists = true, WebHookURl = "/", IsTransacted = false, isExpired = false, ExpiresAt = FixedUtcNow }; 

--- a/Test/Test/BackendAPI/Modules/PhilSys.UnitTests/PhilSysServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.UnitTests/PhilSysServiceTests.cs
@@ -25,7 +25,7 @@ namespace Test.BackendAPI.Modules.PhilSys.UnitTests
 		public async Task GetPhilsysTokenAsync_ShouldThrow_WhenRequestFails()
 		{
 			// Arrange
-			var client_id = Guid.NewGuid().ToString();
+			var client_id = Guid.CreateVersion7().ToString();
 			var client_secret = "YnQpGs34mdlH24234234EhRc0pJXAjQASDdASdjvihbujtuLxHt51";
 			_fixture.MockHttpClientFactory.Setup(f => f.CreateClient("PhilSys")).Returns(() =>
 			{
@@ -57,7 +57,7 @@ namespace Test.BackendAPI.Modules.PhilSys.UnitTests
 		public async Task GetPhilsysTokenAsync_ShouldReturnToken_WhenResponseIsSuccessful()
 		{
 			// Arrange
-			var client_id = Guid.NewGuid().ToString();
+			var client_id = Guid.CreateVersion7().ToString();
 			var client_secret = "YnQpGs34mdlH24234234EhRc0pJXAjQASDdASdjvihbujtuLxHt51";
 			var expectedToken = "fake-token";
 			_fixture.MockHttpClientFactory.Setup(f => f.CreateClient("PhilSys")).Returns(() =>

--- a/Test/Test/BackendAPI/Modules/PhilSys.UnitTests/UpdateFaceLivenessSessionServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/PhilSys.UnitTests/UpdateFaceLivenessSessionServiceTests.cs
@@ -46,7 +46,7 @@ namespace Test.BackendAPI.Modules.PhilSys.UnitTests
 			var face_liveness_session_id = "valid-session-id";
 			var philsysTransaction = new PhilSysTransaction
 			{
-				Tid = Guid.NewGuid(),
+				Tid = Guid.CreateVersion7(),
 				InquiryType = "pcn",
 				PCN = "6786785465456459",
 				HashToken = "hash-token",
@@ -101,7 +101,7 @@ namespace Test.BackendAPI.Modules.PhilSys.UnitTests
 			var face_liveness_session_id = "valid-session-id";
 			var philsysTransaction = new PhilSysTransaction
 			{
-				Tid = Guid.NewGuid(),
+				Tid = Guid.CreateVersion7(),
 				InquiryType = "pcn",
 				PCN = "6786785465456459",
 				HashToken = "hash-token",

--- a/Test/Test/BackendAPI/Modules/Philsys.UnitTests/DeleteTransactionServiceTests.cs
+++ b/Test/Test/BackendAPI/Modules/Philsys.UnitTests/DeleteTransactionServiceTests.cs
@@ -36,7 +36,7 @@ namespace Test.BackendAPI.Modules.Philys.UnitTests
 			// Arrange
 			var service = _fixture.DeleteTransactionService;
 			var transaction = new PhilSysTransaction {
-				Tid = Guid.NewGuid(),
+				Tid = Guid.CreateVersion7(),
 				InquiryType = "pcn",
 				PCN = "9700018324631576",
 				WebHookUrl = "/",
@@ -60,7 +60,7 @@ namespace Test.BackendAPI.Modules.Philys.UnitTests
 		{
 			// Arrange
 			var service = _fixture.DeleteTransactionService;
-			var transactionId = Guid.NewGuid();
+			var transactionId = Guid.CreateVersion7();
 			var hashToken = "HabaL5avPCryiszlRKNU7Q9xClqKEq5h2FWNLdMNEpo";
 			var transaction = new PhilSysTransaction
 			{

--- a/UI/FrontendWebassembly/Services/AIAgentChat/Implementation/AIChatService.cs
+++ b/UI/FrontendWebassembly/Services/AIAgentChat/Implementation/AIChatService.cs
@@ -32,7 +32,7 @@ public class AIChatService : IAIAgentChatService
 		CancellationToken cancellationToken)
 	{
 		// Resolve user id (adjust to your LocalStorageService API)
-		var userId = await _localStorageService.GetItemAsync<string?>(_userIdKey) ?? Guid.NewGuid().ToString();
+		var userId = await _localStorageService.GetItemAsync<string?>(_userIdKey) ?? Guid.CreateVersion7().ToString();
 
 		await EnsureHubConnectionStartedAsync(userId, cancellationToken);
 


### PR DESCRIPTION
All usages of Guid.NewGuid() have been replaced with Guid.CreateVersion7() across the BackendAPI codebase and tests. This ensures that all new GUIDs are time-ordered (UUIDv7), which can improve database indexing and query performance. The change affects entity creation, DTOs, service logic, and all relevant test cases.