### PR TITLE
Update MudBlazor to version 9.6.0 in FrontendWebassembly

### DIFF
--- a/UI/FrontendWebassembly/FrontendWebassembly.csproj
+++ b/UI/FrontendWebassembly/FrontendWebassembly.csproj
@@ -21,7 +21,7 @@
 		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 		<PackageReference Include="Microsoft.SemanticKernel.Core" Version="1.76.0" />
 		<PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-		<PackageReference Include="MudBlazor" Version="9.4.0" />
+		<PackageReference Include="MudBlazor" Version="9.6.0" />
 		<PackageReference Include="System.IO.Packaging" Version="10.0.8" />
 	</ItemGroup>
 


### PR DESCRIPTION
Upgraded the MudBlazor NuGet package from version 9.4.0 to 9.6.0 in FrontendWebassembly.csproj to incorporate the latest features, improvements, and bug fixes.