### PR TITLE
Remove forced reloads from navigation and update auth checks

### DIFF
--- a/UI/FrontendWebassembly/Layout/MainLayout.razor.cs
+++ b/UI/FrontendWebassembly/Layout/MainLayout.razor.cs
@@ -115,7 +115,14 @@ public partial class MainLayout
 
 			if (!isAuthenticated)
 			{
-				Navigation.NavigateTo("/login", true);
+				var isDarkMode = await LocalStorageService.GetItemAsync<bool?>("isDarkMode");
+				await LocalStorageService.ClearAsync();
+				if (isDarkMode.HasValue)
+				{
+					await LocalStorageService.SetItemAsync("isDarkMode", isDarkMode.Value);
+				}
+
+				Navigation.NavigateTo("/login");
 
 				return;
 			}
@@ -165,7 +172,7 @@ public partial class MainLayout
 			if (logout)
 			{
 				Console.WriteLine(logout ? "Logout successful." : "Logout failed.");
-				Navigation.NavigateTo("/login", true);
+				Navigation.NavigateTo("/login");
 
 				return;
 			}

--- a/UI/FrontendWebassembly/Pages/Auth/Login.razor.cs
+++ b/UI/FrontendWebassembly/Pages/Auth/Login.razor.cs
@@ -23,7 +23,7 @@ public partial class Login
 
 		if (isAuthenticated)
 		{
-			Navigation.NavigateTo("/", true);
+			Navigation.NavigateTo("/");
 			return;
 		}
 
@@ -57,7 +57,7 @@ public partial class Login
 				return;
 			}
 
-			Navigation.NavigateTo("/", true);
+			Navigation.NavigateTo("/");
 		}
 
 		catch (Exception ex)

--- a/UI/FrontendWebassembly/Pages/Auth/Otp.razor.cs
+++ b/UI/FrontendWebassembly/Pages/Auth/Otp.razor.cs
@@ -34,7 +34,7 @@ public partial class Otp
 		// Check if email parameter exists
 		if (string.IsNullOrWhiteSpace(email) && string.IsNullOrWhiteSpace(userId))
 		{
-			Navigation.NavigateTo("/register", true);
+			Navigation.NavigateTo("/register");
 			return;
 		}
 
@@ -46,7 +46,7 @@ public partial class Otp
 		{
 			await LocalStorageService.RemoveItemAsync("tempUserId");
 			await LocalStorageService.RemoveItemAsync("tempUserEmail");
-			Navigation.NavigateTo("/login", true);
+			Navigation.NavigateTo("/login");
 			return;
 		}
 

--- a/UI/FrontendWebassembly/Pages/Auth/Register.razor.cs
+++ b/UI/FrontendWebassembly/Pages/Auth/Register.razor.cs
@@ -26,12 +26,12 @@ public partial class Register
 
 	protected override async Task OnInitializedAsync()
 	{
-		var isAuthenticated = await IAuthService.IsAuthenticated();
+		var userId = await LocalStorageService.GetItemAsync<Guid>("UserId");
 
-		if (isAuthenticated)
+		if (userId != Guid.Empty)
 		{
 
-			Navigation.NavigateTo("/", true);
+			Navigation.NavigateTo("/");
 			return;
 		}
 
@@ -105,7 +105,7 @@ public partial class Register
 			}
 			await LocalStorageService.SetItemAsync("tempUserId", result.id);
 			await LocalStorageService.SetItemAsync("tempUserEmail", result.email);
-			Navigation.NavigateTo("/verify-otp", true);
+			Navigation.NavigateTo("/verify-otp");
 		}
 		catch (Exception ex)
 		{

--- a/UI/FrontendWebassembly/Pages/Auth/ResetPassword.razor.cs
+++ b/UI/FrontendWebassembly/Pages/Auth/ResetPassword.razor.cs
@@ -121,7 +121,7 @@ public partial class ResetPassword
 			if (redirectCountdown <= 0)
 			{
 				countdownTimer?.Dispose();
-				await InvokeAsync(() => Navigation.NavigateTo("/login", true));
+				await InvokeAsync(() => Navigation.NavigateTo("/login"));
 			}
 			else
 			{


### PR DESCRIPTION
Removed forced reloads from Navigation.NavigateTo calls across multiple components to enable smoother client-side navigation. MainLayout now preserves the "isDarkMode" setting when clearing local storage on logout. Register component now checks for a non-empty "UserId" in local storage instead of using IAuthService.IsAuthenticated() for redirect logic.