### PR TITLE
Improve Blazor WASM caching and routing in nginx.conf

### DIFF
--- a/UI/FrontendWebassembly/nginx.conf
+++ b/UI/FrontendWebassembly/nginx.conf
@@ -5,14 +5,21 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
-    # Blazor WebAssembly framework files (cache aggressively)
-    location /_framework/ {
+    # Never cache index.html to avoid serving stale boot manifest/SRI metadata
+    location = /index.html {
+        add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
+
+    # Blazor WebAssembly framework files (must never fall back to index.html)
+    location ^~ /_framework/ {
+        try_files $uri =404;
         expires 1y;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
 
     # Blazor static web assets from packages/libraries
-    location /_content/ {
+    location ^~ /_content/ {
+        try_files $uri =404;
         expires 1y;
         add_header Cache-Control "public, max-age=31536000, immutable";
     }
@@ -38,6 +45,6 @@ server {
 
     # Required for Blazor WebAssembly client-side routing
     location / {
-        try_files $uri /index.html;
+        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
Added no-cache for index.html, strict 404 for framework/content files, and enhanced client-side routing support.